### PR TITLE
Updating how OPL problem statistics works.

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -962,7 +962,7 @@ build_library_textbook_tree($ce,$dbh);
 
 $dbh->disconnect;
 
-if ($ce->{problemLibrary}{showLibraryStats}) {
+if ($ce->{problemLibrary}{showLibraryLocalStats}) {
   print "\nUpdating Library Statistics.\n";
   do $ENV{WEBWORK_ROOT}.'/bin/update-OPL-statistics';
 }

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -542,10 +542,12 @@ $problemLibrary_db = {
 
 $problemLibrary{tree} = 'library-directory-tree.json';
 
-# This flag controls if statistics on opl problems are shown in the library
+# These flags control if statistics on opl problems are shown in the library
 # browser.  If you want to include local statistics you will need to
 # run webwork2/bin/update-OPL-statistics on a regular basis.  
-$problemLibrary{showLibraryStats} = 1;
+$problemLibrary{showLibraryLocalStats} = 1;
+# This flag controls whether global statistics will be displayed
+$problemLibrary{showLibraryGlobalStats} = 1;
 
 ################################################################################
 # Logs

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -126,10 +126,12 @@ $webworkFiles{screenSnippets}{setHeader}         = "$webworkDirs{conf}/snippets/
 $problemLibrary{root}       = "/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
 $problemLibrary{version}    = "2.5";  
 
-# This flag controls if statistics on opl problems are shown in the library
+# These flags control if statistics on opl problems are shown in the library
 # browser.  If you want to include local statistics you will need to
 # run webwork2/bin/update-OPL-statistics on a regular basis.  
-$problemLibrary{showLibraryStats} = 1;
+$problemLibrary{showLibraryLocalStats} = 1;
+# This flag controls whether global statistics will be displayed
+$problemLibrary{showLibraryGlobalStats} = 1;
 
 # Additional library buttons can be added to the Library Browser (SetMaker.pm)
 # by adding the libraries you want to the following line.  For each key=>value

--- a/htdocs/helpFiles/Global_Average_Attempts_Data.html
+++ b/htdocs/helpFiles/Global_Average_Attempts_Data.html
@@ -1,0 +1,33 @@
+<html>
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+<head>
+<title>Global Attempts</title>
+</head>
+
+<body><br>
+<p>
+The Attempts figure is the global average of the number of attempts
+(both correct and incorrect) individuals take on this problem. 
+A high figure may represent a difficult problem.  Note that problems
+with multiple parts may have higher average attempts since many students 
+will submit an answer to each part before continuing and each such 
+submittal counts as an attempt.
+</p>
+
+
+</body>
+</html>

--- a/htdocs/helpFiles/Global_Average_Status_Data.html
+++ b/htdocs/helpFiles/Global_Average_Status_Data.html
@@ -1,0 +1,38 @@
+<html>
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+<head>
+<title>Global Status</title>
+</head>
+
+<body><br>
+<p>
+The Status figure is the global average of the Status
+individuals have earned on this problem. The Status is the percentage
+correct (from 0% to 100%) recorded for the problem.  A low figure may 
+represent a difficult problem.  The Status is often fairly high since 
+many students will work on a problem until they get it correct or nearly so.
+</p>
+
+<p>
+Reviewing a problem and looking at both the average Attempts and 
+average Status should give instructors valuable information about
+the difficulty of the problem.
+</p>
+
+
+</body>
+</html>

--- a/htdocs/helpFiles/Global_Usage_Data.html
+++ b/htdocs/helpFiles/Global_Usage_Data.html
@@ -1,0 +1,32 @@
+<html>
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+<head>
+<title>Global Usage Data</title>
+</head>
+
+<body><br>
+<p>
+Global data on problem usage is contributed by many institutions using
+WeBWorK all over the world. The Usage figure is the total number of 
+individuals who have attemped this problem at least once. A high figure
+represents a problem which has been assigned to many students and is 
+both popular with instructors and likely bug free.
+</p>
+
+
+</body>
+</html>

--- a/htdocs/helpFiles/Local_Average_Attempts_Data.html
+++ b/htdocs/helpFiles/Local_Average_Attempts_Data.html
@@ -1,0 +1,33 @@
+<html>
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+<head>
+<title>Local Attempts</title>
+</head>
+
+<body><br>
+<p>
+The Attempts figure is the local average of the number of attempts
+(both correct and incorrect) individuals at your institution take on this problem. 
+A high figure may represent a difficult problem.  Note that problems
+with multiple parts may have higher average attempts since many students 
+will submit an answer to each part before continuing and each such 
+submittal counts as an attempt.
+</p>
+
+
+</body>
+</html>

--- a/htdocs/helpFiles/Local_Average_Status_Data.html
+++ b/htdocs/helpFiles/Local_Average_Status_Data.html
@@ -1,0 +1,38 @@
+<html>
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+<head>
+<title>Local Status</title>
+</head>
+
+<body><br>
+<p>
+The Status figure is the local average of the Status
+individuals at your institution have earned on this problem. The Status is the percentage
+correct (from 0% to 100%) recorded for the problem.  A low figure may 
+represent a difficult problem.  The Status is often fairly high since 
+many students will work on a problem until they get it correct or nearly so.
+</p>
+
+<p>
+Reviewing a problem and looking at both the average Attempts and 
+average Status should give instructors valuable information about
+the difficulty of the problem.
+</p>
+
+
+</body>
+</html>

--- a/htdocs/helpFiles/Local_Usage_Data.html
+++ b/htdocs/helpFiles/Local_Usage_Data.html
@@ -1,0 +1,34 @@
+<html>
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+<head>
+<title>Local Usage Data</title>
+</head>
+
+<body><br>
+<p>
+Local data on problem usage is generated and maintained by your institution. 
+The Usage figure is the total number of local
+individuals who have attemped this problem at least once. A high figure
+represents a problem which has been assigned to many students and is 
+both popular with instructors and likely bug free.
+
+Local data is generated when your systems admin runs the script update-OPL-statistics.
+</p>
+
+
+</body>
+</html>

--- a/lib/WeBWorK/Utils/LibraryGlobalStats.pm
+++ b/lib/WeBWorK/Utils/LibraryGlobalStats.pm
@@ -15,13 +15,13 @@
 
 
 ###########################
-# Utils::LibrarySTats
+# Utils::LibraryGlobalStats
 #
-# This is an interface for getting statistics about library problems
+# This is an interface for getting global statistics about library problems
 # for display 
 ###########################
 
-package WeBWorK::Utils::LibraryStats;
+package WeBWorK::Utils::LibraryGlobalStats;
 
 use base qw(Exporter);
 use strict;
@@ -44,7 +44,7 @@ sub new {
 		RaiseError => 0,
 	    },
 	);
-    my $selectstm = $dbh->prepare("SELECT * FROM OPL_local_statistics WHERE source_file = ?");
+    my $selectstm = $dbh->prepare("SELECT * FROM OPL_global_statistics WHERE source_file = ?");
     
     my $self = { dbh => $dbh,
 		 selectstm => $selectstm,
@@ -54,7 +54,7 @@ sub new {
     return $self;
 }
 
-sub getLocalStats {
+sub getGlobalStats {
     my $self = shift;
     my $source_file = shift;
 
@@ -62,7 +62,7 @@ sub getLocalStats {
 
     unless ($selectstm->execute($source_file)) {
       if ($selectstm->errstr =~ /Table .* doesn't exist/) {
-	warn "Couldn't find the OPL local statistics table.  Are you sure you have run update-OPL-statistics?"
+	warn "Couldn't find the OPL global statistics table.  Check that this table exists."
       }
       die $selectstm->errstr;
     }

--- a/lib/WeBWorK/Utils/LibraryLocalStats.pm
+++ b/lib/WeBWorK/Utils/LibraryLocalStats.pm
@@ -1,0 +1,83 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright � 2000-1307 The WeBWorK Project, http://openwebwork.sf.net/
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+
+###########################
+# Utils::LibraryLocalStats
+#
+# This is an interface for getting local statistics about library problems
+# for display 
+###########################
+
+package WeBWorK::Utils::LibraryLocalStats;
+
+use base qw(Exporter);
+use strict;
+use warnings;
+use DBI;
+
+our @EXPORT    = ();
+our @EXPORT_OK = qw();
+
+sub new {
+    my $class = shift;
+    my $ce = shift;
+
+    my $dbh = DBI->connect(
+	$ce->{problemLibrary_db}->{dbsource},
+	$ce->{problemLibrary_db}->{user},
+	$ce->{problemLibrary_db}->{passwd},
+	    {
+		PrintError => 0,
+		RaiseError => 0,
+	    },
+	);
+    my $selectstm = $dbh->prepare("SELECT * FROM OPL_local_statistics WHERE source_file = ?");
+    
+    my $self = { dbh => $dbh,
+		 selectstm => $selectstm,
+    };
+
+    bless($self,$class);
+    return $self;
+}
+
+sub getLocalStats {
+    my $self = shift;
+    my $source_file = shift;
+
+    my $selectstm = $self->{selectstm};
+
+    unless ($selectstm->execute($source_file)) {
+      if ($selectstm->errstr =~ /Table .* doesn't exist/) {
+	warn "Couldn't find the OPL local statistics table.  Are you sure you have run update-OPL-statistics?"
+      }
+      die $selectstm->errstr;
+    }
+
+    my $result = $selectstm->fetchrow_arrayref();
+
+    if ($result) {
+	return {source_file => $source_file,
+		students_attempted => $$result[1],
+		average_attempts => $$result[2],
+		average_status => $$result[3],
+	};
+    } else {
+	return {source_file => $source_file};
+    }
+}
+    
+1;


### PR DESCRIPTION
```
modified:   bin/OPL-update
modified:   conf/defaults.config
modified:   conf/localOverrides.conf.dist
new file:   htdocs/helpFiles/Global_Average_Attempts_Data.html
new file:   htdocs/helpFiles/Global_Average_Status_Data.html
new file:   htdocs/helpFiles/Global_Usage_Data.html
new file:   htdocs/helpFiles/Local_Average_Attempts_Data.html
new file:   htdocs/helpFiles/Local_Average_Status_Data.html
new file:   htdocs/helpFiles/Local_Usage_Data.html
modified:   lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
new file:   lib/WeBWorK/Utils/LibraryGlobalStats.pm
renamed:    lib/WeBWorK/Utils/LibraryStats.pm -> lib/WeBWorK/Utils/LibraryLocalStats.pm
```

To test this you need to run update-OPL-statistics which creates the table OPL_local_statistics in the MySQL webwork database. You also need the table OPL_global_statistics which has the same structure as OPL_local_statistics. For testing purposes, you can just copy OPL_local_statistics to OPL_global_statistics.
