### PR TITLE
Add hack to set version so that the script runs without warnings in

### DIFF
--- a/bin/update-OPL-statistics
+++ b/bin/update-OPL-statistics
@@ -25,6 +25,11 @@ BEGIN{ die('You need to set the WEBWORK_ROOT environment variable.\n')
 use lib "$ENV{WEBWORK_ROOT}/lib";
 use WeBWorK::CourseEnvironment;
 
+# hack to set version so that the script runs without warnings in 
+# earlier versions of WeBWorK, e.g. WW 2.7
+
+BEGIN { $main::VERSION = "2.4"; } 
+
 BEGIN{ 
     my $ce = new WeBWorK::CourseEnvironment({
 	webwork_dir => $ENV{WEBWORK_ROOT},


### PR DESCRIPTION
Add hack to set version so that the script runs without warnings in 
earlier versions of WeBWorK, e.g. WW 2.7
