### PR TITLE
Clean up error messages.

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -12,6 +12,9 @@
 
 $debug_lti_parameters = 0; # set this to 1 to have LTI calling parameters printed to HTML page for debugging
 
+# edit these variables as necessary: $preferred_source_of_username, $strip_address_from_email
+# and  $LTIBasicConsumerSecret
+# The others can be left with default values during the initial configuration.
 
 ###################
 $authen{user_module} = [ 
@@ -78,8 +81,8 @@ $authen{user_module} = [
 # lis_person_sourceid, one must nevertheless use
 # the correct spelling here, i.e. "lis_person_sourcedid".
 
-$preferred_source_of_username = "lis_person_sourcedid";
-#$preferred_source_of_username = "lis_person_contact_email_primary";
+#$preferred_source_of_username = "lis_person_sourcedid";
+$preferred_source_of_username = "lis_person_contact_email_primary";
 
 # Some LMS systems, Blackboard in particular, do not send lis_person_sourcedid
 # if you enable this flag and have $preferred_source_of_username set to
@@ -91,8 +94,10 @@ $strip_address_from_email = 1;
 # LTI Basic Authentication Parameters 
 ################################################################################
 
-# This consumer secret is set in the LMS and needs to be included here. 
-$LTIBasicConsumerSecret = "WeBWorKLTIB";
+# This "shared secret" is entered in the LMS request form and needs to be match the entry here. 
+# you should choose your own secret word for security.
+$LTIBasicConsumerSecret = "WeBWorK_LTI";  
+# The LMS will have a different shared secret for each LTI tool that it communicates with. 
 
 # This allows you to override the URL that Oauth will use to validate the 
 # authentication.  This is important if you have some sort of setup (e.g. load


### PR DESCRIPTION
These error messages are aimed at making it easier to set up the initial communication between WeBWorK and the
LMS calling WeBWorK via LTI.

Also commented out some preliminary code to be used at Rochester for deducing sections from the Blackboard course_label at
UR.

A lot of the authentication procedure is as described in the comments and specific to the needs of IU.  A future update
should breakout the process of assigning recitations and sections into a callback subroutine so that it is easier to
program in different behaviors for handling this task.  This will do for now.
